### PR TITLE
Improve speed of C-Version and fix makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-nya:
-	cc nya.c -O3 -o nya
+nya: nya.c
+	cc nya.c -std=c17 -O3 -o nya
 clean:
 	rm -f nya
 install:

--- a/nya.c
+++ b/nya.c
@@ -26,7 +26,7 @@ int main(int argc, char* argv[]) {
         printf("Usage: %s <length>\n", argv[0]);
         return 1;
     }
-    unsigned long arg = atol(argv[1]);
+    u_int64_t arg = atoll(argv[1]);
     u_int64_t state = arg;
     for(int i = 0; i < 100; i++) {
         rand_merge(&state, time(NULL));

--- a/nya.c
+++ b/nya.c
@@ -4,9 +4,10 @@
 #include <time.h>
 #include <string.h>
 
-const char* NYAS[] = {"nya ", "nya~ ", "mew ", "meow ", "mrrp ", ":3 ", "meowmeow ", "mow "};
+const char* NYAS = "nya     nya~    mew     meow    mrrp    :3      meowmeowmow     ";
+
 const size_t NYALENS[] = {4, 5, 4, 5, 5, 3, 9, 4};
-const size_t MAX = sizeof(NYAS) / sizeof(char*);
+const size_t MAX = sizeof(NYALENS) / sizeof(size_t);
 
 size_t rnd(u_int64_t* state) {
     u_int64_t s = *state;
@@ -31,17 +32,27 @@ int main(int argc, char* argv[]) {
         rand_merge(&state, time(NULL));
     }
     char buf[16384];
+    memset(buf, ' ', sizeof(buf));
     while(arg > 0) {
         u_int16_t n = 0;
         while(arg > 0 && n < 16370) {
             size_t i = rnd(&state);
-            const char* nya = NYAS[i];
+            const char* nya = NYAS + i*8;
             size_t nyalen = NYALENS[i];
-            memcpy(buf + n, nya, nyalen);
-            n += nyalen;
+            memcpy(&buf[n], nya, 8);
+            n = n + nyalen;
             arg -= 1;
         }
+
+        if (arg == 0) {
+            // replace the last whitespace with a newline
+            // to prevent breaking some terminals
+            buf[n-1] = '\n';
+        }
         fwrite(buf, 1, n, stdout);
+        memset(buf, ' ', sizeof(buf));
     }
+
+    (void)state;
     return 0;
 }


### PR DESCRIPTION
Henlo there,

this improves the speed of the C version further. Additionally, it now prints a newline at the end of the output - so it no longer shows a percentage sign at the end on zsh for example, the makefile now correctly recompiles when the main.c file changes and let user inputs be larger than the 32bit integer limit.

nya~ :3 :3 nya~ mew mrrp mew mow mew :3 :3 mew meowmeow mow :3 mrrp nya~ nya mow nya meow nya~ mrrp nya~ :3